### PR TITLE
add selector d'image pour user avatar + test seed validé

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-debug.log*
 *.swp
 .DS_Store
 .env*
+.env*

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,6 @@
 class PagesController < ApplicationController
   skip_before_action :authenticate_user!, only: :home
-
+  params.require(:user).permit(:first_name, :last_name, :email, :password, :photo)
   def home
   end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -16,6 +16,7 @@
                 required: false,
                 autofocus: true,
                 input_html: { autocomplete: "photo" }%>
+    <%= f.input :photo_cache, as: :hidden %>
     <%= f.input :email,
                 required: true,
                 autofocus: true,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,6 @@
   </head>
   <body>
     <%= render 'shared/navbar' %>
-    <%= yield %>
     <%= render 'shared/flashed' %>
     <%= yield %>
     <%= javascript_include_tag 'application' %>


### PR DESCRIPTION
test seed validé, cela bugg-ait sur la version de Mn en raison de l'absence du ficher .env à créer sur chacunes de nos versions avec nos clés cloudinary respectives
Ajout de la possibilité de télécharger une photo de profil pour le user à l'inscription. 